### PR TITLE
Instructions for using Android Studio.

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -1,6 +1,6 @@
 Preliminary Setup (ADT/Glass Debug)
 ===================================
-* Download/Unpack Android SDK (ADT Bundle): http://developer.android.com/sdk/index.html
+* Download/Unpack Android SDK (ADT Bundle): http://developer.android.com/sdk/index.html or Android Studio: http://developer.android.com/sdk/installing/studio.html
 * Setup the ADT paths (e.g., the "adb" command should be in the path).  This can be accomplished with something like this in your .bashrc (replace $ADT with the path) "export PATH=$PATH:$ADT/sdk/tools:$ADT/sdk/platform-tools".
 * Put Glass in debug mode (Settings -> Device Info -> Turn on debug)
 * Installed third party apk's: cd openglass/android/thirdparty  then bash install.sh
@@ -12,9 +12,22 @@ Binary Install (not-recommended)
 Source Install (recommended)
 ===============================
 * Download/Unpack OpenCV: http://sourceforge.net/projects/opencvlibrary/files/opencv-android/2.4.6/OpenCV-2.4.6-android-sdk-r2.zip/download
+
+ADT/Eclipse
+-----------
 * Open ADT eclipse, New->Project->Android Project From Existing Code (do this for <OpenCV dir>/sdk and openglass/android)
 * In ADT, Right click on OpenGlass -> Properties -> Android under Library click "Add", then select the OpenCV Library.  Alternatively, you can manually set the path in openglass/android/project.properties at "android.library.reference.1=".
 * Install to the device by selecting, Run -> Run As... -> Android Application
+
+Android Studio/IntelliJ
+-----------------------
+* Import Project, select openglass/android
+* Import Module, select <OpenCV dir>/sdk
+	- deselect sample directories 
+* Project Structure->Modules->"android"->Dependencies-> + -> Module Dependency->"android"
+* Run -> Edit Configurations, add an Android Application run configuration for 
+module "android". Check "Deploy application" and "Show chooser dialog".
+* Run (either from Run menu or by clicking the "play" button in the toolbar)
 
 Post Install
 ============


### PR DESCRIPTION
You may want to see if you can reproduce this.

Notes:
1. We might want to distribute project files instead of using "Import" to create new projects.
2. We're using the "old" build system in Android Studio, switching to Gradle is a low-priority todo.
3. The name of the project/module should be "openglass" instead of "android" -- distributing our own project files would allow us to do this without complicating the instructions or having nested "openglass" folders.
