### PR TITLE
Updated windows install batch to include new path to the adb.exe

### DIFF
--- a/glass/thirdparty/install_binary_windows.bat
+++ b/glass/thirdparty/install_binary_windows.bat
@@ -1,4 +1,4 @@
-adb install OpenCV_2.4.6_Manager_2.9_armv7a-neon.apk
-adb install launchy.apk
-adb install CaptureActivity.apk
-adb install wearscript.apk
+adb\windows\adb.exe install OpenCV_2.4.6_Manager_2.9_armv7a-neon.apk
+adb\windows\adb.exe install launchy.apk
+adb\windows\adb.exe install CaptureActivity.apk
+adb\windows\adb.exe install wearscript.apk


### PR DESCRIPTION
Someone added some binaries for adb to the thirdparty directory. It makes sense to just have the windows users now utilize this than ask them to create path variables.
