### PR TITLE
add camera_id option to specify a camera other than 0

### DIFF
--- a/hardware/eyetracker/track.py
+++ b/hardware/eyetracker/track.py
@@ -192,7 +192,7 @@ def parse_calibration(calib, command_func, command_thresh):
     return plot_point
 
 def pupil_iter(pupil_intensity, pupil_ratio, debug=False, dump=None, load=None, plot=False, calib=None, func=None, command_func=None, **kw):
-    camera_id = 0
+    camera_id = kw.get('camera_id')
     camera = cv2.VideoCapture(camera_id)
     camera.set(cv2.cv.CV_CAP_PROP_FRAME_WIDTH, 640)
     camera.set(cv2.cv.CV_CAP_PROP_FRAME_HEIGHT, 480)
@@ -267,6 +267,7 @@ def main():
     parser.add_argument('--command_thresh', type=int, default=6)
     parser.add_argument('--calib')
     parser.add_argument('--command_keyboard')
+    parser.add_argument('--camera_id', type=int, default=0)
     parser.add_argument('--plot', action='store_true')
     subparser = subparsers.add_parser('server')
     subparser.add_argument('--port', type=int, default=8080)


### PR DESCRIPTION
My laptop was trying to use my built-in webcam by default. Needed to specify camera id 1 and figured it should be an option.
