### PR TITLE
reverse order of gist list so new ones show up first on Glass

### DIFF
--- a/WearScript/src/main/java/com/dappervision/wearscript/models/InstalledScripts.java
+++ b/WearScript/src/main/java/com/dappervision/wearscript/models/InstalledScripts.java
@@ -10,6 +10,7 @@ import org.json.simple.JSONValue;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 public class InstalledScripts {
@@ -28,7 +29,9 @@ public class InstalledScripts {
         String[] flArray = extStorageDir.list();
         if (flArray == null)
             return new ArrayList<String>();
-        return Arrays.asList(flArray);
+        List<String> gists = Arrays.asList(flArray);
+        Collections.reverse(gists);
+        return gists;
     }
 
     public void load() {


### PR DESCRIPTION
I find it annoying that when I make a new gist and start working on it, it's always at the end of the list after all the old ones. This fixes that.

Note: the assumption / observation that they always come out chronological / reverse chronological is empirical, I haven't checked the gist api to verify it's in the spec.
