### PR TITLE
Speech cancel

### DIFF
--- a/WearScript/src/main/java/com/dappervision/wearscript/managers/SpeechManager.java
+++ b/WearScript/src/main/java/com/dappervision/wearscript/managers/SpeechManager.java
@@ -35,7 +35,7 @@ public class SpeechManager extends Manager {
                 spokenText = Base64.encodeToString(spokenText.getBytes(), Base64.NO_WRAP);
                 makeCall(SPEECH, String.format("\"%s\"", spokenText));
             } else if (resultCode == Activity.RESULT_CANCELED) {
-
+                makeCall(SPEECH, "\"\"");
             }
         }
     }


### PR DESCRIPTION
Return empty string to the callback when speechrecognize is canceled by the user. This allows the app to react when the speechrecognizer is canceled, e.g. by re-initiating speech recognition. 
