### PR TITLE
set background of html card webview to black on instantiation

### DIFF
--- a/WearScript/src/main/java/com/dappervision/wearscript/managers/CardTreeManager.java
+++ b/WearScript/src/main/java/com/dappervision/wearscript/managers/CardTreeManager.java
@@ -128,6 +128,7 @@ public class CardTreeManager extends Manager {
             return c.getView();
         } else if (type.equals("html")) {
             WebView wv = new WebView(service);
+            wv.setBackgroundColor(0);
             wv.setInitialScale(100);
             String body = "<html style='width:100%; height:100%; overflow:hidden; background-color:#000000'><head><link href='roboto.css' rel='stylesheet' type='text/css'><link rel='stylesheet' href='base_style.css'></head><body style='width:100%; height:100%; overflow:hidden; margin:0'>" + card.get("html") + "</body></html>";
             Log.d(TAG, body);


### PR DESCRIPTION
  The previous commit (92cfdafcfe180b5774e0935f3033f0f4d7899e3b) that
    tried to take care of this missed the stage of loading where the view
    has been instantiated but the body not loaded yet. When the body is
    small this stage is of negligible length, but it shows up when the
    body is big.
