### PR TITLE
allow link navigation

### DIFF
--- a/WearScript/src/main/java/com/dappervision/wearscript/BackgroundService.java
+++ b/WearScript/src/main/java/com/dappervision/wearscript/BackgroundService.java
@@ -17,6 +17,7 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import android.webkit.WebViewClient;
 
 import com.dappervision.wearscript.dataproviders.BatteryDataProvider;
 import com.dappervision.wearscript.dataproviders.DataPoint;


### PR DESCRIPTION
When trying to navigate to a new URL like this:

```
window.location.href="glass2.html";
```

I was getting the error:

```
calling startActivity() from outside of an Activity context requires the FLAG_ACTIVITY_NEW_TASK flag. Is this really what you want?
```

I found [the way to fix this](http://stackoverflow.com/questions/20976344/andorid-daydream-sevice-webview-context-requires-the-flag-activity-new-task-fla) on a StackOverflow comment.
